### PR TITLE
fix: add return in list_tags_for_resource

### DIFF
--- a/src/spaceone/inventory/connector/aws_rds_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_rds_connector/connector.py
@@ -341,7 +341,7 @@ class RDSConnector(SchematicAWSConnector):
 
     def list_tags_for_resource(self, resource_name):
         response = self.client.list_tags_for_resource(ResourceName=resource_name)
-        self.convert_tags_to_dict_type(response.get('TagList', []))
+        return self.convert_tags_to_dict_type(response.get('TagList', []))
 
     @staticmethod
     def get_region(azs):

--- a/src/spaceone/inventory/connector/aws_rds_connector/schema/data.py
+++ b/src/spaceone/inventory/connector/aws_rds_connector/schema/data.py
@@ -113,7 +113,7 @@ class SubnetGroupSubnets(Model):
     subnet_status = StringType(deserialize_from="SubnetStatus")
 
 
-class SubnetGroup(Model):
+class SubnetGroup(AWSCloudService):
     db_subnet_group_name = StringType(deserialize_from="DBSubnetGroupName")
     db_subnet_group_description = StringType(deserialize_from="DBSubnetGroupDescription")
     vpc_id = StringType(deserialize_from="VpcId")
@@ -135,7 +135,7 @@ class Features(Model):
     value = StringType(deserialize_from="Value")
 
 
-class Snapshot(Model):
+class Snapshot(AWSCloudService):
     db_snapshot_identifier = StringType(deserialize_from="DBSnapshotIdentifier")
     db_instance_identifier = StringType(deserialize_from="DBInstanceIdentifier")
     snapshot_create_time = DateTimeType(deserialize_from="SnapshotCreateTime")


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Found that all tags values of RDS resources is None. 
Fixed this bug caused by not putting return in the `list_tags_for_resource` method.

### Known issue
* https://github.com/cloudforet-io/plugin-aws-cloud-service-inven-collector/issues/7