### PR TITLE
Add cloudtrail data for AccessKey

### DIFF
--- a/src/spaceone/inventory/connector/aws_iam_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_iam_connector/connector.py
@@ -11,7 +11,7 @@ from spaceone.inventory.connector.aws_iam_connector.schema.resource import Group
     IdentityProviderResponse, AccessKeyResource, AccessKeyResponse
 from spaceone.inventory.connector.aws_iam_connector.schema.service_type import CLOUD_SERVICE_TYPES
 from spaceone.inventory.libs.connector import SchematicAWSConnector
-from spaceone.inventory.libs.schema.resource import ReferenceModel, ErrorResourceResponse
+from spaceone.inventory.libs.schema.resource import ReferenceModel, ErrorResourceResponse, CloudTrailModel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -353,6 +353,7 @@ class IAMConnector(SchematicAWSConnector):
 
     def list_access_keys(self, user_name, user_arn):
         self.cloud_service_type = 'AccessKey'
+        cloudtrail_resource_type = 'AWS::IAM::AccessKey'
 
         access_keys = []
         _filter = {'UserName': user_name}
@@ -372,7 +373,17 @@ class IAMConnector(SchematicAWSConnector):
                     'create_date': access_key_meta.get('CreateDate'),
                     'access_key_last_used': access_key_last_used_vo,
                     'last_update_date_display': self.get_last_update_date_display(access_key_last_used_vo),
-                    'status': str(access_key_meta.get('Status', ''))
+                    'status': str(access_key_meta.get('Status', '')),
+                    'cloudtrail': CloudTrailModel({
+                        'LookupAttributes': [
+                            {
+                                "AttributeKey": "AccessKeyId",
+                                "AttributeValue": key_id,
+                            }
+                        ],
+                        'region_name': 'us-east-1',
+                        'resource_type': cloudtrail_resource_type
+                    }, strict=False),
                 }
                 access_keys.append(access_key_vo)
 

--- a/src/spaceone/inventory/connector/aws_iam_connector/schema/service_type.py
+++ b/src/spaceone/inventory/connector/aws_iam_connector/schema/service_type.py
@@ -399,7 +399,6 @@ cst_access_key.tags = {
 
 cst_access_key._metadata = CloudServiceTypeMeta.set_meta(
     fields=[
-        TextDyField.data_source('Access Key ID', 'data.key_id'),
         EnumDyField.data_source('Status', 'data.status',
                                 default_badge={'indigo.500': ['Active'], 'coral.600': ['Inactive']}),
         TextDyField.data_source('User name', 'data.user_name'),

--- a/src/spaceone/inventory/libs/connector.py
+++ b/src/spaceone/inventory/libs/connector.py
@@ -220,7 +220,7 @@ class SchematicAWSConnector(AWSConnector):
         return None
 
     @staticmethod
-    def set_cloudtrail(region_name, resource_type, resource_name, **custom_query):
+    def set_cloudtrail(region_name, resource_type, resource_name):
         cloudtrail = {
             'LookupAttributes': [
                 {
@@ -231,9 +231,6 @@ class SchematicAWSConnector(AWSConnector):
             'region_name': region_name,
             'resource_type': resource_type
         }
-
-        if custom_query:
-            cloudtrail = custom_query
 
         return CloudTrailModel(cloudtrail, strict=False)
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
1. Duplicate values of `Name` field and `Access Key ID` field, which are automatically added to table metadata. Excluding the `Access Key ID` field.
2. Setting up CloudTrail metadata to get the log history value of `AccessKey` cloud service.

### Known issue
* https://github.com/cloudforet-io/plugin-aws-cloud-service-inven-collector/issues/12
