### PR TITLE
Remove resource_type in IAM.AccessKey

### DIFF
--- a/src/spaceone/inventory/connector/aws_iam_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_iam_connector/connector.py
@@ -353,7 +353,6 @@ class IAMConnector(SchematicAWSConnector):
 
     def list_access_keys(self, user_name, user_arn):
         self.cloud_service_type = 'AccessKey'
-        cloudtrail_resource_type = 'AWS::IAM::AccessKey'
 
         access_keys = []
         _filter = {'UserName': user_name}
@@ -381,8 +380,7 @@ class IAMConnector(SchematicAWSConnector):
                                 "AttributeValue": key_id,
                             }
                         ],
-                        'region_name': 'us-east-1',
-                        'resource_type': cloudtrail_resource_type
+                        'region_name': 'us-east-1'
                     }, strict=False),
                 }
                 access_keys.append(access_key_vo)


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Remove `resource_type` in `data.cloudtrail` in IAM.AccessKey.
In the case of the history for the access key, the filter should not work because history for all events must be retrieved.

### Related issue
* https://github.com/cloudforet-io/plugin-aws-cloud-service-inven-collector/issues/12
* https://github.com/cloudforet-io/plugin-aws-cloudtrail-mon-datasource/issues/9