### PR TITLE
Add resource_type for Access Key

### DIFF
--- a/src/spaceone/inventory/connector/aws_iam_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_iam_connector/connector.py
@@ -353,6 +353,7 @@ class IAMConnector(SchematicAWSConnector):
 
     def list_access_keys(self, user_name, user_arn):
         self.cloud_service_type = 'AccessKey'
+        cloudtrail_resource_type = 'AWS::IAM::AccessKey'
 
         access_keys = []
         _filter = {'UserName': user_name}
@@ -380,6 +381,7 @@ class IAMConnector(SchematicAWSConnector):
                                 "AttributeValue": key_id,
                             }
                         ],
+                        'resource_type': cloudtrail_resource_type,
                         'region_name': 'us-east-1'
                     }, strict=False),
                 }


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Setting resource_type to get CloudTrail log by access key

### Related issue
* https://github.com/cloudforet-io/plugin-aws-cloud-service-inven-collector/issues/12